### PR TITLE
issues55-缓解下压测时误杀的概率

### DIFF
--- a/src/main/java/com/github/netty/protocol/servlet/ServletContext.java
+++ b/src/main/java/com/github/netty/protocol/servlet/ServletContext.java
@@ -98,6 +98,10 @@ public class ServletContext implements javax.servlet.ServletContext {
      * Upload file timeout millisecond , -1 is not control timeout.
      */
     long uploadFileTimeoutMs = -1;
+    /**
+     * 客户端断开后，如果超过abortAfterMessageTimeoutMs后，还没有收到完整的body，则抛出abort异常
+     */
+    long abortAfterMessageTimeoutMs = 500;
     private Supplier<Executor> asyncExecutorSupplier;
     private SessionService sessionService;
     private Set<SessionTrackingMode> sessionTrackingModeSet;
@@ -241,6 +245,14 @@ public class ServletContext implements javax.servlet.ServletContext {
 
     public void setUploadFileTimeoutMs(long uploadFileTimeoutMs) {
         this.uploadFileTimeoutMs = uploadFileTimeoutMs;
+    }
+
+    public void setAbortAfterMessageTimeoutMs(long abortAfterMessageTimeoutMs) {
+        this.abortAfterMessageTimeoutMs = abortAfterMessageTimeoutMs;
+    }
+
+    public long getAbortAfterMessageTimeoutMs() {
+        return abortAfterMessageTimeoutMs;
     }
 
     public boolean isUseRelativeRedirects() {

--- a/src/main/java/com/github/netty/springboot/NettyProperties.java
+++ b/src/main/java/com/github/netty/springboot/NettyProperties.java
@@ -335,6 +335,10 @@ public class NettyProperties implements Serializable {
          */
         private long uploadFileTimeoutMs = -1;
         /**
+         * 客户端断开后，如果超过abortAfterMessageTimeoutMs后，还没有收到完整的body，则抛出abort异常
+         */
+        private long abortAfterMessageTimeoutMs = 500;
+        /**
          * 不会出现在body中的字段. 仅限于 multipart/form-data, application/x-www-form-urlencoded. （为了避免因为要获取某个字段，一直在等客户端发完数据。）
          */
         private String[] notExistBodyParameter = {"_method", "JSESSIONID"};
@@ -385,6 +389,14 @@ public class NettyProperties implements Serializable {
          * 启动失败是否停止程序.
          */
         private boolean startupFailExit = true;
+
+        public long getAbortAfterMessageTimeoutMs() {
+            return abortAfterMessageTimeoutMs;
+        }
+
+        public void setAbortAfterMessageTimeoutMs(long abortAfterMessageTimeoutMs) {
+            this.abortAfterMessageTimeoutMs = abortAfterMessageTimeoutMs;
+        }
 
         public boolean isEnableUrlServletAntPathMatcher() {
             return enableUrlServletAntPathMatcher;

--- a/src/main/java/com/github/netty/springboot/server/HttpServletProtocolSpringAdapter.java
+++ b/src/main/java/com/github/netty/springboot/server/HttpServletProtocolSpringAdapter.java
@@ -96,6 +96,7 @@ public class HttpServletProtocolSpringAdapter extends HttpServletProtocol {
         servletContext.setEnableLookupFlag(httpServlet.isEnableNsLookup());
         servletContext.setAutoFlush(httpServlet.getAutoFlushIdleMs() > 0);
         servletContext.setUploadFileTimeoutMs(httpServlet.getUploadFileTimeoutMs());
+        servletContext.setAbortAfterMessageTimeoutMs(httpServlet.getAbortAfterMessageTimeoutMs());
         servletContext.setContextPath(webServerFactory.getContextPath());
         servletContext.setServerHeader(webServerFactory.getServerHeader());
         servletContext.setServletContextName(webServerFactory.getDisplayName());


### PR DESCRIPTION

     * 触发客户端断开有两种情况
     * 情况1. 客户端提前断开，确实没将body传完
     * 情况2. 客户端没提前断开，将body传完了，只是服务端IO忙不过来了。
     * 因为服务端IO忙不过来时，服务端无法区分出情况1还是情况2，所以靠定期检查，如果规定时间内还没收到新body，则真正触发abort。


```java


    /**
     * 触发客户端断开有两种情况
     * 情况1. 客户端提前断开，确实没将body传完
     * 情况2. 客户端没提前断开，将body传完了，只是服务端IO忙不过来了。
     * 因为服务端IO忙不过来时，服务端无法区分出情况1还是情况2，所以靠定期检查，如果规定时间内还没收到新body，则真正触发abort。
     */
    void abort() {
        if (isReceived()) {
            return;
        }
        this.checkMessageChangeFuture = scheduleCheckAbortAfterMessageTimeout();
    }

    /**
     * 客户端断开后，如果超过abortAfterMessageTimeoutMs后，还没有收到完整的body，则抛出abort异常
     *
     * @return 任务Future
     */
    private ScheduledFuture<?> scheduleCheckAbortAfterMessageTimeout() {
        // 记录下执行前收到的数据大小
        long snapshotLength = this.receivedContentLength.get();
        int snapshotVersion = this.version.get();

        // 使用GlobalEventExecutor去schedule。
        // 这时不能使用EventLoop线程去schedule，因为造成超时的原因是EventLoop处理IO事件忙不过来了，不能再给它加任务了。
        return GlobalEventExecutor.INSTANCE.schedule(() -> {
                    if (snapshotVersion != this.version.get() || this.closed.get() || isReceived()) {
                        return;
                    }
                    // timeout后仍然没有收到新的长度
                    if (snapshotLength == this.receivedContentLength.get()) {
                        // 标记终止, 抛给前端
                        this.abort = true;
                        this.checkMessageChangeFuture = null;
                        close();
                        // 释放等待读body的线程
                        conditionSignalAll();
                    } else {
                        // 可以收到新的body bytes，只是比较慢，应该是在压测中。
                        // 继续开始下次超时检测
                        this.checkMessageChangeFuture = scheduleCheckAbortAfterMessageTimeout();
                    }
                },
                httpExchange.servletContext.abortAfterMessageTimeoutMs, TimeUnit.MILLISECONDS);
    }
``` 